### PR TITLE
Large FASTQ Modifications

### DIFF
--- a/Combine_IronThrone_Parallel_Output.R
+++ b/Combine_IronThrone_Parallel_Output.R
@@ -37,7 +37,7 @@ concatenate_got <- function(BC, split_df){
 #Identify all unique barcodes in the data frame and run the concatenating function 
 unique_bc <- unique(split_got_df[,"BC"])
 concat_got_df <- as.data.frame(Reduce(rbind, mclapply(unique_bc, FUN = function(x) (concatenate_got(BC = x, split_df = split_got_df)))), stringsAsFactors = FALSE)
-write.table(concat_got_df, file = "../myGoT.summTable.concat.txt", sep = "\t", row.names = FALSE, col.names = TRUE)
+write.table(concat_got_df, file = "../myGoT.summTable.concat.txt", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
 
 
 #Collapse UMIs #####
@@ -153,4 +153,4 @@ UMI_collapse <- function(GoT_table){
 max_collapsed_GoT_table <- UMI_collapse(raw_GoT_table)
 
 #Save output
-write.table(max_collapsed_GoT_table, file = "../myGoT.summTable.concat.umi_collapsed.txt", sep = "\t", row.names = FALSE, col.names = TRUE)
+write.table(max_collapsed_GoT_table, file = "../myGoT.summTable.concat.umi_collapsed.txt", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)

--- a/Combine_IronThrone_Parallel_Output.R
+++ b/Combine_IronThrone_Parallel_Output.R
@@ -4,6 +4,7 @@ wd <- options[1]
 pcr_thresh <- as.numeric(options[2])
 ld <- as.numeric(options[3])
 dupcut <- as.numeric(options[4])
+threads <- as.numeric(options[5])
 
 setwd(wd)
 library(parallel)
@@ -36,7 +37,7 @@ concatenate_got <- function(BC, split_df){
 
 #Identify all unique barcodes in the data frame and run the concatenating function 
 unique_bc <- unique(split_got_df[,"BC"])
-concat_got_df <- as.data.frame(Reduce(rbind, mclapply(unique_bc, FUN = function(x) (concatenate_got(BC = x, split_df = split_got_df)))), stringsAsFactors = FALSE)
+concat_got_df <- as.data.frame(Reduce(rbind, mclapply(unique_bc, FUN = function(x) (concatenate_got(BC = x, split_df = split_got_df)), mc.cores = threads)), stringsAsFactors = FALSE)
 write.table(concat_got_df, file = "../myGoT.summTable.concat.txt", sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
 
 
@@ -144,7 +145,7 @@ UMI_collapse <- function(GoT_table){
                                       stringsAsFactors = FALSE)
   #Convert the GoT data frame into a list of single-row data frames where each entry is the data for a single cell barcode
   GoT_list <- split(GoT_table_to_collapse, seq(nrow(GoT_table_to_collapse)))
-  collapsed_GoT_list <- mclapply(GoT_list, FUN = list_collapse)
+  collapsed_GoT_list <- mclapply(GoT_list, FUN = list_collapse, mc.cores = threads)
   #Convert collapsed list back to a data frame
   collapsed_GoT_table <- do.call("rbind", collapsed_GoT_list)
   return(collapsed_GoT_table)

--- a/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
@@ -194,15 +194,15 @@ then
 	fi
 
 
-	split -d -a 3 -l $target_lines shuffled.R1.fastq shuffled.R1
-	split -d -a 3 -l $target_lines shuffled.R2.fastq shuffled.R2
+	split -d -a 4 -l $target_lines shuffled.R1.fastq shuffled.R1
+	split -d -a 4 -l $target_lines shuffled.R2.fastq shuffled.R2
 
 	total_files=$(ls shuffled.R1[0-9]* | wc -l)
 
 	#Move split fastq files into shuffled_split directory
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
 	mkdir shuffled_split
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
 	echo R1 and R2 split into $total_files pieces
 
 	mkdir preprocessing_fastqs
@@ -235,7 +235,7 @@ touch ../Parallel_Command_List.txt
 
 #Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
 total_files=0
-for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
+for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
 do
 R1=$(pwd)'/'$(ls | grep "R1${i}");
 R2=$(pwd)'/'$(ls | grep "R2${i}");

--- a/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
@@ -144,7 +144,7 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if ($low_mem == 1)
+	if (($low_mem == 1))
 	then
 		if (($(grep ";" combined.fastq | wc -l) == 0))
 		then

--- a/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
@@ -26,6 +26,7 @@ pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
 low_mem=0
+threads=$(nproc)
 
 
 #Set Up Command Line Options
@@ -93,6 +94,9 @@ while [ "$1" != "" ]; do
 					;;
 		-lm | --low_mem )		shift
 					low_mem=$1
+					;;
+		-t | --threads )		shift
+					threads=$1
 					;;
 	esac
 	shift
@@ -270,7 +274,7 @@ cd ..
 #Run list of IronThrone commands on split fastqs using GNU Parallel
 if ((skip_iron_throne != 1))
 then
-	parallel :::: Parallel_Command_List.txt
+	parallel -j ${threads} :::: Parallel_Command_List.txt
 
 	echo All instances of IronThrone complete
 fi

--- a/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
@@ -143,11 +143,11 @@ then
 	#Randomly sort lines of combined R1/R2 file
 	if (($(grep ";" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	elif (($(grep "|" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	else
 		echo "New awk-line character needed"

--- a/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 #Navigate to directory out of which parallelization script is being run
 cd $(dirname $0)
 
@@ -26,6 +25,7 @@ skip_shuf=0
 pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
+low_mem=0
 
 
 #Set Up Command Line Options
@@ -91,6 +91,9 @@ while [ "$1" != "" ]; do
 		-ld | --levenshtein_distance )	shift
 					levenshtein_distance=$1
 					;;
+		-lm | --low_mem )		shift
+					low_mem=$1
+					;;
 	esac
 	shift
 done
@@ -141,18 +144,35 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if (($(grep ";" combined.fastq | wc -l) == 0))
+	if ($low_mem == 1)
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
-		echo fastq files shuffled
-	elif (($(grep "|" combined.fastq | wc -l) == 0))
-	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
-		echo fastq files shuffled
+		if (($(grep ";" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		elif (($(grep "|" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		else
+			echo "New awk-line character needed"
+			exit 1
+		fi
 	else
-		echo "New awk-line character needed"
-		exit 1
+		if (($(grep ";" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		elif (($(grep "|" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		else
+			echo "New awk-line character needed"
+			exit 1
+		fi
 	fi
+
 
 	#Separate shuffled file back into R1 and R2
 	cut -f1 -d$'\t' combined_shuffled.fastq > shuffled.R1.fastq

--- a/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUCluster.sh
@@ -225,73 +225,74 @@ cd Output/
 main_output_folder=$(pwd)
 
 cd ..
-cd shuffled_split/
 
 if ((skip_iron_throne != 1))
 then
-	echo Begin job parallelization
-fi
+	cd shuffled_split/
+
+	if ((skip_iron_throne != 1))
+	then
+		echo Begin job parallelization
+	fi
 
 
-#Create text file of commands for GNU Parallel to execute
-touch ../Parallel_Command_List.txt
->../Parallel_Command_List.txt
+	#Create text file of commands for GNU Parallel to execute
+	touch ../Parallel_Command_List.txt
+	>../Parallel_Command_List.txt
 
-#Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
-total_files=0
-for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
-do
-R1=$(pwd)'/'$(ls | grep "R1${i}");
-R2=$(pwd)'/'$(ls | grep "R2${i}");
-output=${main_output_folder}'/'${i}
-mkdir -p ${output};
+	#Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
+	total_files=0
+	for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
+	do
+	R1=$(pwd)'/'$(ls | grep "R1${i}");
+	R2=$(pwd)'/'$(ls | grep "R2${i}");
+	output=${main_output_folder}'/'${i}
+	mkdir -p ${output};
 
-echo "module load got/0.1; \
-IronThrone-GoT \
--r ${run} \
--f1 ${R1} \
--f2 ${R2} \
--c ${config} \
--w ${whitelist} \
--u ${umilen} \
--b ${bclen} \
--o ${output} \
--m ${mmtch} \
--p ${postP} \
--d 1 \
--s ${sample} \
--l ${log} \
--k ${keepouts} \
--v ${verbose}" >> ../Parallel_Command_List.txt
-
-
-done
-
-#Back to main level folder
-cd ..
+	echo "module load got/0.1; \
+	IronThrone-GoT \
+	-r ${run} \
+	-f1 ${R1} \
+	-f2 ${R2} \
+	-c ${config} \
+	-w ${whitelist} \
+	-u ${umilen} \
+	-b ${bclen} \
+	-o ${output} \
+	-m ${mmtch} \
+	-p ${postP} \
+	-d 1 \
+	-s ${sample} \
+	-l ${log} \
+	-k ${keepouts} \
+	-v ${verbose}" >> ../Parallel_Command_List.txt
 
 
-#Run list of IronThrone commands on split fastqs using GNU Parallel
-if ((skip_iron_throne != 1))
-then
+	done
+
+	#Back to main level folder
+	cd ..
+
+	#Run list of IronThrone commands on split fastqs using GNU Parallel
 	parallel -j ${threads} :::: Parallel_Command_List.txt
 
 	echo All instances of IronThrone complete
 fi
 
-
 #Call R script to concatenate and collapse output
-Rscript Combine_IronThrone_Parallel_Output.R $main_output_folder ${pcr_read_threshold} ${levenshtein_distance} ${dupcut}
+Rscript Combine_IronThrone_Parallel_Output.R $main_output_folder ${pcr_read_threshold} ${levenshtein_distance} ${dupcut} ${threads}
 
-echo All IronThrone outputs concatenated into myGoT.summTable.concat.txt
+echo All IronThrone outputs concatenated into myGoT.summTable.concat.umi_collapsed.txt
 
 outdir=$(readlink -f $outdir)
 
-if [ ! -f $outdir'/myGoT.summTable.concat.txt' ]
+if [ ! -f $outdir'/myGoT.summTable.concat.umi_collapsed.txt' ]
 then
 	mv myGoT.summTable.concat.txt $outdir
 	mv myGoT.summTable.concat.umi_collapsed.txt $outdir
 fi
 
-
-rm Parallel_Command_List.txt
+if ((skip_iron_throne != 1))
+then
+	rm Parallel_Command_List.txt
+fi

--- a/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
@@ -197,15 +197,15 @@ then
 	fi
 
 
-	split -d -a 3 -l $target_lines shuffled.R1.fastq shuffled.R1
-	split -d -a 3 -l $target_lines shuffled.R2.fastq shuffled.R2
+	split -d -a 4 -l $target_lines shuffled.R1.fastq shuffled.R1
+	split -d -a 4 -l $target_lines shuffled.R2.fastq shuffled.R2
 
 	total_files=$(ls shuffled.R1[0-9]* | wc -l)
 
 	#Move split fastq files into shuffled_split directory
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
 	mkdir shuffled_split
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
 	echo R1 and R2 split into $total_files pieces
 
 	mkdir preprocessing_fastqs
@@ -237,7 +237,7 @@ touch ../Parallel_Command_List.txt
 
 #Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
 total_files=0
-for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
+for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
 do
 R1=$(pwd)'/'$(ls | grep "R1${i}");
 R2=$(pwd)'/'$(ls | grep "R2${i}");

--- a/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
@@ -26,6 +26,7 @@ iron_throne_loc=./IronThrone-GoT
 pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
+low_mem=0
 
 
 #Set Up Command Line Options
@@ -94,6 +95,9 @@ while [ "$1" != "" ]; do
 		-ld | --levenshtein_distance )	shift
 					levenshtein_distance=$1
 					;;
+		-lm | --low_mem )		shift
+					low_mem=$1
+					;;
 	esac
 	shift
 done
@@ -144,17 +148,33 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if (($(grep ";" combined.fastq | wc -l) == 0))
+	if ($low_mem == 1)
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
-		echo fastq files shuffled
-	elif (($(grep "|" combined.fastq | wc -l) == 0))
-	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
-		echo fastq files shuffled
+		if (($(grep ";" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		elif (($(grep "|" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		else
+			echo "New awk-line character needed"
+			exit 1
+		fi
 	else
-		echo "New awk-line character needed"
-		exit 1
+		if (($(grep ";" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		elif (($(grep "|" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		else
+			echo "New awk-line character needed"
+			exit 1
+		fi
 	fi
 
 	#Separate shuffled file back into R1 and R2

--- a/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
@@ -146,11 +146,11 @@ then
 	#Randomly sort lines of combined R1/R2 file
 	if (($(grep ";" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	elif (($(grep "|" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	else
 		echo "New awk-line character needed"

--- a/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
@@ -148,7 +148,7 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if ($low_mem == 1)
+	if (($low_mem == 1))
 	then
 		if (($(grep ";" combined.fastq | wc -l) == 0))
 		then

--- a/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNULinux.sh
@@ -27,6 +27,7 @@ pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
 low_mem=0
+threads=$(nproc)
 
 
 #Set Up Command Line Options
@@ -97,6 +98,9 @@ while [ "$1" != "" ]; do
 					;;
 		-lm | --low_mem )		shift
 					low_mem=$1
+					;;
+		-t | --threads )		shift
+					threads=$1
 					;;
 	esac
 	shift
@@ -270,7 +274,7 @@ cd ..
 #Run list of IronThrone commands on split fastqs using GNU Parallel
 if ((skip_iron_throne != 1))
 then
-	parallel :::: Parallel_Command_List.txt
+	parallel -j ${threads} :::: Parallel_Command_List.txt
 
 	echo All instances of IronThrone complete
 fi

--- a/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
@@ -26,6 +26,7 @@ iron_throne_loc=./IronThrone-GoT
 pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
+low_mem=0
 
 
 #Set Up Command Line Options
@@ -94,6 +95,9 @@ while [ "$1" != "" ]; do
 		-ld | --levenshtein_distance )	shift
 					levenshtein_distance=$1
 					;;
+		-lm | --low_mem )		shift
+					low_mem=$1
+					;;
 	esac
 	shift
 done
@@ -144,17 +148,33 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if (($(grep ";" combined.fastq | wc -l) == 0))
+	if ($low_mem == 1)
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
-		echo fastq files shuffled
-	elif (($(grep "|" combined.fastq | wc -l) == 0))
-	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
-		echo fastq files shuffled
+		if (($(grep ";" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		elif (($(grep "|" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		else
+			echo "New awk-line character needed"
+			exit 1
+		fi
 	else
-		echo "New awk-line character needed"
-		exit 1
+		if (($(grep ";" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		elif (($(grep "|" combined.fastq | wc -l) == 0))
+		then
+			awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
+			echo fastq files shuffled
+		else
+			echo "New awk-line character needed"
+			exit 1
+		fi
 	fi
 
 	#Separate shuffled file back into R1 and R2

--- a/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
@@ -146,11 +146,11 @@ then
 	#Randomly sort lines of combined R1/R2 file
 	if (($(grep ";" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	elif (($(grep "|" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	else
 		echo "New awk-line character needed"

--- a/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
@@ -197,15 +197,15 @@ then
 	fi
 
 
-	gsplit -d -a 3 -l $target_lines shuffled.R1.fastq shuffled.R1
-	gsplit -d -a 3 -l $target_lines shuffled.R2.fastq shuffled.R2
+	gsplit -d -a 4 -l $target_lines shuffled.R1.fastq shuffled.R1
+	gsplit -d -a 4 -l $target_lines shuffled.R2.fastq shuffled.R2
 
 	total_files=$(ls shuffled.R1[0-9]* | wc -l)
 
 	#Move split fastq files into shuffled_split directory
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
 	mkdir shuffled_split
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
 	echo R1 and R2 split into $total_files pieces
 
 	mkdir preprocessing_fastqs
@@ -237,7 +237,7 @@ touch ../Parallel_Command_List.txt
 
 #Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
 total_files=0
-for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
+for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
 do
 R1=$(pwd)'/'$(ls | grep "R1${i}");
 R2=$(pwd)'/'$(ls | grep "R2${i}");

--- a/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
@@ -228,65 +228,66 @@ cd Output/
 main_output_folder=$(pwd)
 
 cd ..
-cd shuffled_split/
 
 if ((skip_iron_throne != 1))
 then
-	echo Begin job parallelization
-fi
+	cd shuffled_split/
 
-#Create text file of commands for GNU Parallel to execute
-touch ../Parallel_Command_List.txt
->../Parallel_Command_List.txt
+	if ((skip_iron_throne != 1))
+	then
+		echo Begin job parallelization
+	fi
 
-#Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
-total_files=0
-for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
-do
-R1=$(pwd)'/'$(ls | grep "R1${i}");
-R2=$(pwd)'/'$(ls | grep "R2${i}");
-output=${main_output_folder}'/'${i}
-mkdir -p ${output};
+	#Create text file of commands for GNU Parallel to execute
+	touch ../Parallel_Command_List.txt
+	>../Parallel_Command_List.txt
 
-echo "${iron_throne_loc} \
--r ${run} \
--f1 ${R1} \
--f2 ${R2} \
--c ${config} \
--w ${whitelist} \
--u ${umilen} \
--b ${bclen} \
--o ${output} \
--m ${mmtch} \
--p ${postP} \
--d 1 \
--s ${sample} \
--l ${log} \
--k ${keepouts} \
--v ${verbose}" >> ../Parallel_Command_List.txt
+	#Loop through split R1 and R2 files, creating directories for each split's individual IronThrone run and adding a command to the parallel command list with the corresponding R1 and R2 filenames
+	total_files=0
+	for i in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]' | sed 's/\.fastq//g' | sed 's/.*R[0-9]//g' | sort | uniq);
+	do
+	R1=$(pwd)'/'$(ls | grep "R1${i}");
+	R2=$(pwd)'/'$(ls | grep "R2${i}");
+	output=${main_output_folder}'/'${i}
+	mkdir -p ${output};
+
+	echo "${iron_throne_loc} \
+	-r ${run} \
+	-f1 ${R1} \
+	-f2 ${R2} \
+	-c ${config} \
+	-w ${whitelist} \
+	-u ${umilen} \
+	-b ${bclen} \
+	-o ${output} \
+	-m ${mmtch} \
+	-p ${postP} \
+	-d 1 \
+	-s ${sample} \
+	-l ${log} \
+	-k ${keepouts} \
+	-v ${verbose}" >> ../Parallel_Command_List.txt
 
 
-done
+	done
 
-#Back to main level folder
-cd ..
+	#Back to main level folder
+	cd ..
 
-#Run list of IronThrone commands on split fastqs using GNU Parallel
-if ((skip_iron_throne != 1))
-then
+	#Run list of IronThrone commands on split fastqs using GNU Parallel
 	parallel -j ${threads} :::: Parallel_Command_List.txt
 
 	echo All instances of IronThrone complete
 fi
 
 #Call R script to concatenate and collapse output
-Rscript Combine_IronThrone_Parallel_Output.R $main_output_folder ${pcr_read_threshold} ${levenshtein_distance} ${dupcut}
+Rscript Combine_IronThrone_Parallel_Output.R $main_output_folder ${pcr_read_threshold} ${levenshtein_distance} ${dupcut} ${threads}
 
-echo All IronThrone outputs concatenated into myGoT.summTable.concat.txt
+echo All IronThrone outputs concatenated into myGoT.summTable.concat.umi_collapsed.txt
 
 outdir=$(greadlink -f $outdir)
 
-if [ ! -f $outdir'/myGoT.summTable.concat.txt' ]
+if [ ! -f $outdir'/myGoT.summTable.concat.umi_collapsed.txt' ]
 then
 	mv myGoT.summTable.concat.txt $outdir
 	mv myGoT.summTable.concat.umi_collapsed.txt $outdir

--- a/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
@@ -148,7 +148,7 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if ($low_mem == 1)
+	if (($low_mem == 1))
 	then
 		if (($(grep ";" combined.fastq | wc -l) == 0))
 		then

--- a/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParGNUMacOS.sh
@@ -27,6 +27,7 @@ pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
 low_mem=0
+threads=$(nproc)
 
 
 #Set Up Command Line Options
@@ -97,6 +98,9 @@ while [ "$1" != "" ]; do
 					;;
 		-lm | --low_mem )		shift
 					low_mem=$1
+					;;
+		-t | --threads )		shift
+					threads=$1
 					;;
 	esac
 	shift
@@ -270,7 +274,7 @@ cd ..
 #Run list of IronThrone commands on split fastqs using GNU Parallel
 if ((skip_iron_throne != 1))
 then
-	parallel :::: Parallel_Command_List.txt
+	parallel -j ${threads} :::: Parallel_Command_List.txt
 
 	echo All instances of IronThrone complete
 fi

--- a/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
@@ -247,11 +247,6 @@ mkdir -p ${output};
 cat <<EOF > ../IronThroneCustomInput.sh
 #!/bin/bash
 
-#$ -cwd
-#$ -V
-#$ -pe smp 2
-#$ -l h_vmem=10G
-
 #SBATCH --job-name=IronThronePar
 #SBATCH --partition=${partition}
 #SBATCH --mem=10gb
@@ -321,20 +316,15 @@ rloc=$(readlink -f Combine_IronThrone_Parallel_Output.R)
 cat <<EOF > CombineIronThronePar.sh
 #!/bin/bash
 
-#$ -cwd
-#$ -V
-#$ -pe smp 2
-#$ -l h_vmem=10G
-
 #SBATCH --job-name=IronThroneParConcat
 #SBATCH --partition=${partition}
 #SBATCH --mem=10gb
 #SBATCH --output=%j.log
-#SBATCH --cpus-per-task=16
+#SBATCH --cpus-per-task=${threads}
 
 module load R/3.6.1
 
-Rscript $rloc $main_output_folder ${pcr_read_threshold} ${levenshtein_distance} ${dupcut}
+Rscript $rloc $main_output_folder ${pcr_read_threshold} ${levenshtein_distance} ${dupcut} ${threads}
 
 touch temp
 
@@ -347,11 +337,11 @@ until [ -f temp ]
 do
      sleep 5
 done
-echo All IronThrone outputs concatenated into myGoT.summTable.concat.txt
+echo All IronThrone outputs concatenated into myGoT.summTable.concat.umi_collapsed.txt
 rm temp
 outdir=$(readlink -f $outdir)
 
-if [ ! -f $outdir'/myGoT.summTable.concat.txt' ]
+if [ ! -f $outdir'/myGoT.summTable.concat.umi_collapsed.txt' ]
 then
 	mv myGoT.summTable.concat.txt $outdir
 	mv myGoT.summTable.concat.umi_collapsed.txt $outdir

--- a/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
@@ -147,7 +147,7 @@ then
 
 
 	#Randomly sort lines of combined R1/R2 file
-	if ($low_mem == 1)
+	if (($low_mem == 1))
 	then
 		if (($(grep ";" combined.fastq | wc -l) == 0))
 		then

--- a/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
@@ -145,11 +145,11 @@ then
 	#Randomly sort lines of combined R1/R2 file
 	if (($(grep ";" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | sort -R | tr ";" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":";")}' combined.fastq | shuf | tr ";" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	elif (($(grep "|" combined.fastq | wc -l) == 0))
 	then
-		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | sort -R | tr "|" "\n" > combined_shuffled.fastq
+		awk '{printf("%s%s",$0,(NR%4==0)?"\n":"|")}' combined.fastq | shuf | tr "|" "\n" > combined_shuffled.fastq
 		echo fastq files shuffled
 	else
 		echo "New awk-line character needed"

--- a/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
@@ -196,15 +196,15 @@ then
 	fi
 
 
-	split -d -a 3 -l $target_lines shuffled.R1.fastq shuffled.R1
-	split -d -a 3 -l $target_lines shuffled.R2.fastq shuffled.R2
+	split -d -a 4 -l $target_lines shuffled.R1.fastq shuffled.R1
+	split -d -a 4 -l $target_lines shuffled.R2.fastq shuffled.R2
 
 	total_files=$(ls shuffled.R1[0-9]* | wc -l)
 
 	#Move split fastq files into shuffled_split directory
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "$file.fastq"; done
 	mkdir shuffled_split
-	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
+	for file in $(ls | grep '.*R[0-9][0-9][0-9][0-9][0-9]'); do mv "$file" "./shuffled_split/"; done
 	echo R1 and R2 split into $total_files pieces
 
 	mkdir preprocessing_fastqs

--- a/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
+++ b/Parallelized_UMI_Collapse/IronThroneParSlurm.sh
@@ -27,6 +27,7 @@ pcr_read_threshold=0.5
 skip_iron_throne=0
 levenshtein_distance=0.1
 low_mem=0
+threads=$(nproc)
 
 
 #Set Up Command Line Options
@@ -97,6 +98,9 @@ while [ "$1" != "" ]; do
 					;;
 		-lm | --low_mem )		shift
 					low_mem=$1
+					;;
+		-t | --threads )		shift
+					threads=$1
 					;;
 	esac
 	shift


### PR DESCRIPTION
- Replaced sort -R step with shuf for increased speed, added low memory option to allow for using sort -R if needed
- Lengthened prefix of split files by one number to allow for 10x greater split files
- Add number of threads option to scripts using GNU parallel
- Add number of threads option to UMI collapsing script